### PR TITLE
Updating index.js to use Node v4.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,8 @@ exports.handler = function(event, context) {
 		});
 	}, function(err, images) {
 		if (err) {
-			context.fail(err);
+			context.callbackWaitsForEmptyEventLoop = false;
+			callback(err, 'Failed result');
 		} else {
 			var resizePairs = cross(CONFIG.sizes, images);
 			async.eachLimit(resizePairs, CONFIG.concurrency, function(resizePair, cb) {
@@ -70,9 +71,11 @@ exports.handler = function(event, context) {
 				});
 			}, function(err) {
 				if (err) {
-					context.fail(err);
+					context.callbackWaitsForEmptyEventLoop = false;
+					callback(err, 'Failed result');
 				} else {
-					context.succeed();
+					context.callbackWaitsForEmptyEventLoop = false;
+					callback(null, 'Success message');
 				}
 			});
 		}


### PR DESCRIPTION
As mentioned in AWS documentation to migrate from Node v0.10 to v4.3, context functions would need to be updated to use the new nomenclature.

ref: http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-using-old-runtime.html#transition-to-new-nodejs-runtime

This commit will update the `context` functions of:

* context.fail(object)
* context.succeed()

To Node v4.3 format following what is suggested by the documentation provided by AWS.