### PR TITLE
Updating index.js to match Node v4.3 format

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,8 @@ exports.handler = function(event, context) {
 		});
 	}, function(err, images) {
 		if (err) {
-			context.fail(err);
+			context.callbackWaitsForEmptyEventLoop = false;
+			callback(err, 'Failed result');
 		} else {
 			var resizePairs = cross(CONFIG.sizes, images);
 			async.eachLimit(resizePairs, CONFIG.concurrency, function(resizePair, cb) {
@@ -70,9 +71,11 @@ exports.handler = function(event, context) {
 				});
 			}, function(err) {
 				if (err) {
-					context.fail(err);
+					context.callbackWaitsForEmptyEventLoop = false;
+					callback(err, 'Failed result');
 				} else {
-					context.succeed();
+					context.callbackWaitsForEmptyEventLoop = false;
+					callback(null, 'Success message');
 				}
 			});
 		}

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ exports.handler = function(event, context, callback) {
 	}, function(err, images) {
 		if (err) {
 			context.callbackWaitsForEmptyEventLoop = false;
-			callback(err, 'Failed result');
+			callback(err);
 		} else {
 			var resizePairs = cross(CONFIG.sizes, images);
 			async.eachLimit(resizePairs, CONFIG.concurrency, function(resizePair, cb) {
@@ -73,9 +73,9 @@ exports.handler = function(event, context, callback) {
 			}, function(err) {
 				context.callbackWaitsForEmptyEventLoop = false;
 				if (err) {
-					callback(err, 'Failed result');
+					callback(err);
 				} else {
-					callback(null, 'Success message');
+					callback();
 				}
 			});
 		}

--- a/index.js
+++ b/index.js
@@ -7,13 +7,14 @@ var s3 = new AWS.S3();
 var CONFIG = require("./config.json");
 
 function getImageType(objectContentType) {
-	if (objectContentType === "image/jpeg") {
-		return "jpeg";
-	} else if (objectContentType === "image/png") {
-		return "png";
-	} else {
-		throw new Error("unsupported objectContentType " + objectContentType);
-	}
+    switch (objectContentType) {
+        case "image/jpeg":
+            return "jpeg";
+        case "image/png":
+            return "png";
+        default:
+            throw new Error("Unsupported objectContentType " + objectContentType);
+    }
 }
 
 function cross(left, right) {
@@ -26,7 +27,7 @@ function cross(left, right) {
 	return res;
 }
 
-exports.handler = function(event, context) {
+exports.handler = function(event, context, callback) {
 	console.log("event ", JSON.stringify(event));
 	async.mapLimit(event.Records, CONFIG.concurrency, function(record, cb) {
 		var originalKey = decodeURIComponent(record.s3.object.key.replace(/\+/g, " "));
@@ -70,11 +71,10 @@ exports.handler = function(event, context) {
 					}
 				});
 			}, function(err) {
+				context.callbackWaitsForEmptyEventLoop = false;
 				if (err) {
-					context.callbackWaitsForEmptyEventLoop = false;
 					callback(err, 'Failed result');
 				} else {
-					context.callbackWaitsForEmptyEventLoop = false;
 					callback(null, 'Success message');
 				}
 			});


### PR DESCRIPTION
This merge request will update the callbacks for `succeed` and `fail` based on AWS documentation -  http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-using-old-runtime.html#transition-to-new-nodejs-runtime - aligning with the change for runtime to be Node v4.3.

This comes as a request from AWS on deprecation of Node v0.10 - https://forums.aws.amazon.com/ann.jspa?annID=4345

What it does:

context.succeed is replaced by

```
context.callbackWaitsForEmptyEventLoop = false;
callback(null, 'Success message');
```

context.fail is replaced by 

```
context.callbackWaitsForEmptyEventLoop = false;
callback(err, 'Fail message');
```

Also replaced the if statements for a switch to improve readability.

**Note** this was tested on a real aws lambda before publishing this PR. No errors reported by the lambda.